### PR TITLE
`last_event_id` parameter

### DIFF
--- a/aiohttp_sse_client2/client.py
+++ b/aiohttp_sse_client2/client.py
@@ -64,6 +64,7 @@ class EventSource:
                  on_open=None,
                  on_message=None,
                  on_error=None,
+                 last_event_id: str = '',
                  **kwargs):
         """Construct EventSource instance.
 
@@ -79,6 +80,8 @@ class EventSource:
         :param on_open: event handler for open event
         :param on_message: event handler for message event
         :param on_error: event handler for error event
+        :param last_event_id: specifies the last event ID string of the
+            EventSource object
         :param kwargs: keyword arguments will pass to underlying
             aiohttp request() method.
         """
@@ -99,7 +102,7 @@ class EventSource:
         self._reconnection_time = reconnection_time
         self._orginal_reconnection_time = reconnection_time
         self._max_connect_retry = max_connect_retry
-        self._last_event_id = ''
+        self._last_event_id = last_event_id
         self._kwargs = kwargs
         if 'headers' not in self._kwargs:
             self._kwargs['headers'] = MultiDict()


### PR DESCRIPTION
This PR allows to pass the `last_event_id` to be used at connection time, instead of just only on reconnections handled by the `EventSource` object itself.